### PR TITLE
chore: lower minimum required cmake version to 3.3

### DIFF
--- a/example-projects/advanced-setup/bazel/.gitignore
+++ b/example-projects/advanced-setup/bazel/.gitignore
@@ -1,6 +1,6 @@
 /bazel-*
 *_inputs
 .*_cifuzz_corpus/
-/.cifuzz-*/
+/.cifuzz*/
 /.ijwb/
 /.clwb/

--- a/example-projects/advanced-setup/cmake/.gitignore
+++ b/example-projects/advanced-setup/cmake/.gitignore
@@ -1,5 +1,5 @@
 build/
-.cifuzz-*/
+.cifuzz*/
 *_inputs
 crash-*
 gotest.log

--- a/example-projects/advanced-setup/cmake/CMakeLists.txt
+++ b/example-projects/advanced-setup/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.3)
 project(cmake_example)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/example-projects/advanced-setup/cmake/lib/CMakeLists.txt
+++ b/example-projects/advanced-setup/cmake/lib/CMakeLists.txt
@@ -1,2 +1,1 @@
 add_library(testMe test_me.cpp)
-target_sources(testMe PUBLIC test_me.h)

--- a/example-projects/advanced-setup/cmake/main/src/CMakeLists.txt
+++ b/example-projects/advanced-setup/cmake/main/src/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Deliberately mixing styles here with one subdirectory including a CMakeLists.txt
 # with the definitions and the other being defined in the parent CMakeLists.txt
 add_library(exploreMe explore_me.cpp)
-target_sources(exploreMe PUBLIC explore_me.h)
-
 add_executable(${PROJECT_NAME} main.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE exploreMe)
 target_link_libraries(${PROJECT_NAME} PRIVATE testMe)

--- a/example-projects/advanced-setup/other/.gitignore
+++ b/example-projects/advanced-setup/other/.gitignore
@@ -1,5 +1,5 @@
 build/
-.cifuzz-*/
+.cifuzz*/
 *_inputs
 crash-*
 gotest.log

--- a/example-projects/simple-setup/bazel/.gitignore
+++ b/example-projects/simple-setup/bazel/.gitignore
@@ -1,6 +1,6 @@
 /bazel-*
 *_inputs
 .*_cifuzz_corpus/
-/.cifuzz-*/
+/.cifuzz*/
 /.ijwb/
 /.clwb/

--- a/example-projects/simple-setup/cmake/.gitignore
+++ b/example-projects/simple-setup/cmake/.gitignore
@@ -1,5 +1,5 @@
 build/
-.cifuzz-*/
+.cifuzz*/
 *_inputs
 crash-*
 gotest.log

--- a/example-projects/simple-setup/cmake/CMakeLists.txt
+++ b/example-projects/simple-setup/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.3)
 project(cmake_example)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/example-projects/simple-setup/cmake/src/CMakeLists.txt
+++ b/example-projects/simple-setup/cmake/src/CMakeLists.txt
@@ -1,2 +1,1 @@
 add_library(exploreMe explore_me.cpp)
-target_sources(exploreMe PUBLIC explore_me.h)

--- a/example-projects/simple-setup/other/.gitignore
+++ b/example-projects/simple-setup/other/.gitignore
@@ -4,6 +4,6 @@ libexplore.so
 
 my_fuzz_test
 
-.cifuzz-*/
+.cifuzz*/
 *_inputs
 crash-*

--- a/tutorials/c_cpp/cmake/CMakeLists.txt
+++ b/tutorials/c_cpp/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.3)
 project(cmake_example)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/tutorials/c_cpp/cmake/src/CMakeLists.txt
+++ b/tutorials/c_cpp/cmake/src/CMakeLists.txt
@@ -1,2 +1,1 @@
 add_library(exploreMe explore_me.cpp)
-target_sources(exploreMe PUBLIC explore_me.h)


### PR DESCRIPTION
We lowered our required minimum cmake version to `3.3`. This PR adjusts the used `CMakeLists.txt` files. Moreover the `.gitignore` files for C/C++ projects are adjusted, so that our new `.cifuzz` folder is ignored.